### PR TITLE
Add Dependabot config for bundler and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to schedule weekly version-update PRs for the bundler (Gemfile) and github-actions ecosystems
- Repo-level vulnerability alerts and Dependabot automated security fixes were also enabled directly via the GitHub API (no file needed for those)

## Test plan
- [ ] Confirm Dependabot runs its first scan after merge (check Insights > Dependency graph > Dependabot)