### PR TITLE
Remove github-actions from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## Summary
- Drops the `github-actions` ecosystem from `.github/dependabot.yml`
- That update job has been failing on every run ("Dependabot couldn't find a `<anything>.yml`") since this repo has no `.github/workflows/` files for it to scan
- Keep `bundler` only for now; re-add `github-actions` if/when a workflow file is introduced

## Test plan
- [ ] Confirm Dependabot's Dependency graph tab no longer shows the github-actions error after merge